### PR TITLE
fix: allow non-standard references such as package-info to exist even…

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -175,6 +175,8 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 
 	private static boolean isSpecialType(String identifier) {
 		return identifier.isEmpty()
+				|| "package-info".equals(identifier)
+				|| "module-info".equals(identifier)
 				|| "?".equals(identifier) // is wildcard, used for intersection types
 				|| (identifier.startsWith("<") && identifier.endsWith(">"));
 	}


### PR DESCRIPTION
… if it isn't entirely correct, for the sake of not completely dying when testing certain modules.

This PR relaxes spoon's strictness regarding reference names.