### PR TITLE
fix: try resources shouldn't be repeated.

### DIFF
--- a/src/main/java/spoon/reflect/code/CtTryWithResource.java
+++ b/src/main/java/spoon/reflect/code/CtTryWithResource.java
@@ -27,6 +27,8 @@ import static spoon.reflect.path.CtRole.TRY_RESOURCE;
  */
 public interface CtTryWithResource extends CtTry {
 
+	public static final String RESOURCE_REF_KEY = "###EXISTING_LOCAL_KEY###";
+
 	/**
 	 * Gets the auto-closeable resources of this <code>try</code>. Available
 	 * from Java 7 with the <i>try-with-resource</i> statement.

--- a/src/main/java/spoon/reflect/code/CtTryWithResource.java
+++ b/src/main/java/spoon/reflect/code/CtTryWithResource.java
@@ -27,7 +27,7 @@ import static spoon.reflect.path.CtRole.TRY_RESOURCE;
  */
 public interface CtTryWithResource extends CtTry {
 
-	public static final String RESOURCE_REF_KEY = "###EXISTING_LOCAL_KEY###";
+	String RESOURCE_REF_KEY = "###EXISTING_LOCAL_KEY###";
 
 	/**
 	 * Gets the auto-closeable resources of this <code>try</code>. Available

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -1065,7 +1065,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				tryWithResource.addResource((CtResource<?>) variableRef.getDeclaration().clone().setImplicit(true));
 			} else {
 				// we have to find it manually
-				for (ASTPair pair: this.jdtTreeBuilder.getContextBuilder().stack) {
+				outer: for (ASTPair pair: this.jdtTreeBuilder.getContextBuilder().stack) {
 					final List<CtLocalVariable> variables = pair.element.getElements(new TypeFilter<>(CtLocalVariable.class));
 					for (CtLocalVariable v: variables) {
 						if (v.getSimpleName().equals(variableRef.getSimpleName())) {
@@ -1074,7 +1074,8 @@ public class ParentExiter extends CtInheritanceScanner {
 							final CtLocalVariable clone = v.clone();
 							clone.setImplicit(true);
 							tryWithResource.addResource(clone);
-							break;
+							// Break out of the outer loop, we're done searching.
+							break outer;
 						}
 					}
 				}

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -1073,6 +1073,7 @@ public class ParentExiter extends CtInheritanceScanner {
 							// we clone it in order to comply with the contract of being a tree
 							final CtLocalVariable clone = v.clone();
 							clone.setImplicit(true);
+							clone.putMetadata(CtTryWithResource.RESOURCE_REF_KEY, v.getReference());
 							tryWithResource.addResource(clone);
 							// Break out of the outer loop, we're done searching.
 							break outer;


### PR DESCRIPTION
This PR fixes a problem with spoon's building of try blocks, where the same declaration would be added multiple times as a resource if it is present across multiple parent scopes in the build context.